### PR TITLE
[Feat] 유저 닉네임 조회 api 개발, security를 위한 jwt 코드 추가

### DIFF
--- a/mooney/build.gradle
+++ b/mooney/build.gradle
@@ -52,6 +52,10 @@ dependencies {
     implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
     runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+    //redis
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+    //cache
+    implementation 'org.springframework.boot:spring-boot-starter-cache'
 }
 
 dependencyManagement {

--- a/mooney/src/main/java/tamtam/mooney/domain/auth/service/AuthService.java
+++ b/mooney/src/main/java/tamtam/mooney/domain/auth/service/AuthService.java
@@ -1,5 +1,6 @@
 package tamtam.mooney.domain.auth.service;
 
+import io.jsonwebtoken.Claims;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
@@ -55,23 +56,25 @@ public class AuthService {
     }
 
     public TokenResponseDto refreshAccessToken(String refreshToken) {
-        Long userId = jwtProvider.validateToken(refreshToken);
-        User user = userService.getUserById(userId);
+        jwtProvider.validateRefreshToken(refreshToken);
 
-        if (!user.getRefreshToken().equals(refreshToken)) {
+        Claims claims = jwtProvider.getRefreshTokenClaims(refreshToken);
+        User user = userService.getUserByEmail(claims.getSubject());
+
+        if (user == null || !user.getRefreshToken().equals(refreshToken)) {
             throw new CustomException(ErrorCode.INVALID_TOKEN);
         }
 
-        String newAccessToken = jwtProvider.createAccessToken(userId);
+        String newAccessToken = jwtProvider.generateAccessToken(user.getEmail());
         return new TokenResponseDto(newAccessToken, refreshToken);
     }
 
     // 토큰 생성 및 저장
     private TokenResponseDto generateTokenResponse(User user) {
-        String accessToken = jwtProvider.createAccessToken(user.getUserId());
-        String refreshToken = jwtProvider.createRefreshToken(user.getUserId());
+        String accessToken = jwtProvider.generateAccessToken(user.getEmail());
+        String refreshToken = jwtProvider.generateRefreshToken(user.getEmail());
 
-        userService.updateRefreshToken(user.getUserId(), refreshToken);
+        userService.updateRefreshToken(user.getEmail(), refreshToken);
         return new TokenResponseDto(accessToken, refreshToken);
     }
 

--- a/mooney/src/main/java/tamtam/mooney/domain/auth/service/AuthService.java
+++ b/mooney/src/main/java/tamtam/mooney/domain/auth/service/AuthService.java
@@ -13,8 +13,6 @@ import tamtam.mooney.global.exception.CustomException;
 import tamtam.mooney.global.exception.ErrorCode;
 import tamtam.mooney.global.security.JwtProvider;
 
-import java.util.List;
-
 @Service
 @Transactional
 @RequiredArgsConstructor

--- a/mooney/src/main/java/tamtam/mooney/domain/user/controller/UserController.java
+++ b/mooney/src/main/java/tamtam/mooney/domain/user/controller/UserController.java
@@ -9,10 +9,17 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import tamtam.mooney.domain.user.service.UserService;
 
+
 @Tag(name = "User")
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/users")
 public class UserController {
     private final UserService userService;
+
+    @Operation(summary = "유저 닉네임 조회")
+    @GetMapping("/nickname")
+    public ResponseEntity<?> getUserInfo() {
+        return ResponseEntity.ok().body(userService.getCurrentUserNickname());
+    }
 }

--- a/mooney/src/main/java/tamtam/mooney/domain/user/service/UserService.java
+++ b/mooney/src/main/java/tamtam/mooney/domain/user/service/UserService.java
@@ -1,14 +1,14 @@
 package tamtam.mooney.domain.user.service;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import tamtam.mooney.domain.user.entity.User;
 import tamtam.mooney.domain.user.repository.UserRepository;
 import tamtam.mooney.global.exception.CustomException;
 import tamtam.mooney.global.exception.ErrorCode;
-
-import java.util.Optional;
 
 @Service
 @Transactional
@@ -47,5 +47,17 @@ public class UserService {
             user.setRefreshToken(refreshToken);
             userRepository.save(user);
         });
+    }
+
+    @Transactional(readOnly = true)
+    public String getCurrentUserNickname() {
+        return getCurrentUser().getNickname();
+    }
+
+    @Transactional(readOnly = true)
+    public User getCurrentUser() throws CustomException {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        return userRepository.findByEmail(authentication.getName())
+                .orElseThrow(() -> new CustomException(ErrorCode.NOT_AUTHENTICATED));
     }
 }

--- a/mooney/src/main/java/tamtam/mooney/domain/user/service/UserService.java
+++ b/mooney/src/main/java/tamtam/mooney/domain/user/service/UserService.java
@@ -42,8 +42,8 @@ public class UserService {
         return userRepository.save(user);
     }
 
-    public void updateRefreshToken(Long userId, String refreshToken) {
-        userRepository.findById(userId).ifPresent(user -> {
+    public void updateRefreshToken(String username, String refreshToken) {
+        userRepository.findByEmail(username).ifPresent(user -> {
             user.setRefreshToken(refreshToken);
             userRepository.save(user);
         });

--- a/mooney/src/main/java/tamtam/mooney/global/config/RedisConfig.java
+++ b/mooney/src/main/java/tamtam/mooney/global/config/RedisConfig.java
@@ -1,0 +1,22 @@
+package tamtam.mooney.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.RedisSerializer;
+
+@Configuration
+public class RedisConfig {
+    @Bean
+    public RedisTemplate<String, Object> redisTemplate(RedisConnectionFactory redisConnectionFactory) { // RedisConnectionFactory는 자동으로 구성됨
+        RedisTemplate<String, Object> template = new RedisTemplate<>();
+        template.setConnectionFactory(redisConnectionFactory);
+
+        // JSON 직렬화를 위해 RedisSerializer 설정
+        RedisSerializer<Object> serializer = new GenericJackson2JsonRedisSerializer();
+        template.setDefaultSerializer(serializer);
+        return template;
+    }
+}

--- a/mooney/src/main/java/tamtam/mooney/global/config/SecurityConfig.java
+++ b/mooney/src/main/java/tamtam/mooney/global/config/SecurityConfig.java
@@ -15,7 +15,6 @@ import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
-import tamtam.mooney.global.common.enums.Role;
 
 @Configuration
 @EnableWebSecurity

--- a/mooney/src/main/java/tamtam/mooney/global/config/SecurityConfig.java
+++ b/mooney/src/main/java/tamtam/mooney/global/config/SecurityConfig.java
@@ -47,7 +47,7 @@ public class SecurityConfig {
                         .requestMatchers(PathRequest.toStaticResources().atCommonLocations()).permitAll()
                         .requestMatchers("/auth/**", "/public/**").permitAll()
                         .requestMatchers("/admin/**").hasRole("ADMIN")
-                        .anyRequest().permitAll()); // TODO: 추후 수정
+                        .anyRequest().authenticated());
         ;
         return http.build();
     }

--- a/mooney/src/main/java/tamtam/mooney/global/config/SecurityConfig.java
+++ b/mooney/src/main/java/tamtam/mooney/global/config/SecurityConfig.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.boot.autoconfigure.security.servlet.PathRequest;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpStatus;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
@@ -15,12 +16,22 @@ import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.logout.HttpStatusReturningLogoutSuccessHandler;
+import org.springframework.security.web.authentication.logout.LogoutFilter;
+import tamtam.mooney.global.security.CookieUtil;
+import tamtam.mooney.global.security.CustomLogoutHandler;
+import tamtam.mooney.global.security.JwtAuthenticationFilter;
+import tamtam.mooney.global.security.JwtProvider;
 
 @Configuration
 @EnableWebSecurity
 @EnableMethodSecurity(prePostEnabled = true)
 @RequiredArgsConstructor
 public class SecurityConfig {
+    private final JwtProvider jwtProvider;
+    private final CookieUtil cookieUtil;
+    private final CustomLogoutHandler customLogoutHandler;
+
     @Bean
     public PasswordEncoder passwordEncoder(){
         return new BCryptPasswordEncoder();
@@ -40,13 +51,22 @@ public class SecurityConfig {
                 .httpBasic(AbstractHttpConfigurer::disable)
                 .sessionManagement(config -> config.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .headers(header -> header.frameOptions(HeadersConfigurer.FrameOptionsConfig::sameOrigin))
+                .addFilterBefore(new JwtAuthenticationFilter(jwtProvider, cookieUtil), LogoutFilter.class)
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers("/error", "/favicon.ico",
                                 "/swagger-ui/**", "/swagger-ui.html", "/v3/api-docs", "/v3/api-docs/**").permitAll()
                         .requestMatchers(PathRequest.toStaticResources().atCommonLocations()).permitAll()
                         .requestMatchers("/auth/**", "/public/**").permitAll()
                         .requestMatchers("/admin/**").hasRole("ADMIN")
-                        .anyRequest().authenticated());
+                        .anyRequest().authenticated())
+
+                .logout(logout -> logout
+                        .logoutUrl("/logout") // POST 요청
+                        .deleteCookies("refreshToken") // refreshToken이라는 이름의 쿠키 삭제
+                        .addLogoutHandler(customLogoutHandler) // 로그아웃 시 수행할 추가 동작
+                        .logoutSuccessHandler(new HttpStatusReturningLogoutSuccessHandler(HttpStatus.OK)) // 상태코드 200 반환 위함
+                )
+                .addFilterBefore(new JwtAuthenticationFilter(jwtProvider, cookieUtil), LogoutFilter.class)
         ;
         return http.build();
     }

--- a/mooney/src/main/java/tamtam/mooney/global/config/SwaggerConfig.java
+++ b/mooney/src/main/java/tamtam/mooney/global/config/SwaggerConfig.java
@@ -1,0 +1,53 @@
+package tamtam.mooney.global.config;
+
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.annotations.info.Info;
+import io.swagger.v3.oas.annotations.servers.Server;
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import lombok.RequiredArgsConstructor;
+import org.springdoc.core.models.GroupedOpenApi;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpHeaders;
+
+import java.util.Arrays;
+
+@OpenAPIDefinition(
+        info = @Info(title = "Mooney API", version = "v2"),
+        servers = {
+                @Server(url = "/", description = "Server URL")
+        })
+@RequiredArgsConstructor
+@Configuration
+public class SwaggerConfig {
+
+    @Bean
+    public OpenAPI openAPI() {
+        SecurityScheme bearerAuth = new SecurityScheme()
+                .type(SecurityScheme.Type.HTTP)
+                .scheme("bearer")
+                .bearerFormat("JWT")
+                .in(SecurityScheme.In.HEADER)
+                .name(HttpHeaders.AUTHORIZATION);
+
+        SecurityRequirement securityRequirement = new SecurityRequirement().addList("bearerAuth");
+
+        return new OpenAPI()
+                .components(new Components()
+                        .addSecuritySchemes("bearerAuth",bearerAuth))
+                .security(Arrays.asList(securityRequirement));
+    }
+
+    @Bean
+    public GroupedOpenApi apiGroup() {
+        String[] paths = {"/**"};
+
+        return GroupedOpenApi.builder()
+                .group("service-api-group")
+                .pathsToMatch(paths)
+                .build();
+    }
+}

--- a/mooney/src/main/java/tamtam/mooney/global/exception/ErrorCode.java
+++ b/mooney/src/main/java/tamtam/mooney/global/exception/ErrorCode.java
@@ -33,6 +33,8 @@ public enum ErrorCode {
     INVALID_TOKEN(401, "유효하지 않은 토큰입니다."),
     EXPIRED_ACCESS_TOKEN(401, "만료된 엑세스 토큰입니다."),
     EXPIRED_REFRESH_TOKEN(401, "만료된 리프레시 토큰입니다."),
+    // 쿠키에 리프레시 토큰이 들어있지 않은 경우
+    NO_COOKIE(401, "쿠키에 리프레시 토큰이 존재하지 않습니다."),
 
     // 404 Not Found
     // 각 리소스를 찾지 못함
@@ -45,7 +47,7 @@ public enum ErrorCode {
     // 500 Internal Server Error
     // 외부 API 사용 도중 에러
     EXTERNAL_API_ERROR(500, "외부 API 사용 중 문제가 발생했습니다."),
-    INTERNAL_SERVER_ERROR(500, "서버 내부 오류가 발생했습니다.")
+    INTERNAL_SERVER_ERROR(500, "서버 내부 오류가 발생했습니다."),
     ;
 
     private final int status;

--- a/mooney/src/main/java/tamtam/mooney/global/exception/ErrorCode.java
+++ b/mooney/src/main/java/tamtam/mooney/global/exception/ErrorCode.java
@@ -31,6 +31,8 @@ public enum ErrorCode {
     INVALID_CREDENTIALS(401, "이메일 또는 비밀번호가 올바르지 않습니다."),
     // 유효하지 않은 토큰
     INVALID_TOKEN(401, "유효하지 않은 토큰입니다."),
+    EXPIRED_ACCESS_TOKEN(401, "만료된 엑세스 토큰입니다."),
+    EXPIRED_REFRESH_TOKEN(401, "만료된 리프레시 토큰입니다."),
 
     // 404 Not Found
     // 각 리소스를 찾지 못함
@@ -44,7 +46,6 @@ public enum ErrorCode {
     // 외부 API 사용 도중 에러
     EXTERNAL_API_ERROR(500, "외부 API 사용 중 문제가 발생했습니다."),
     INTERNAL_SERVER_ERROR(500, "서버 내부 오류가 발생했습니다.")
-
     ;
 
     private final int status;

--- a/mooney/src/main/java/tamtam/mooney/global/security/CookieUtil.java
+++ b/mooney/src/main/java/tamtam/mooney/global/security/CookieUtil.java
@@ -1,0 +1,47 @@
+package tamtam.mooney.global.security;
+
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+public class CookieUtil {
+
+    public String getCookieValue(HttpServletRequest request, String name){
+        Cookie[] cookies = request.getCookies();
+        if (cookies == null){
+            return null;
+        }
+        for(Cookie cookie : cookies){
+            if(cookie.getName().equals(name)){
+                return cookie.getValue();
+            }
+        }
+        return null;
+    }
+
+    public void addCookie(HttpServletResponse response, String name, String value, int maxAge){
+        StringBuilder cookieHeader = new StringBuilder();
+        cookieHeader.append(name).append("=").append(value).append(";");
+        cookieHeader.append("Max-Age=").append(maxAge).append(";");
+        cookieHeader.append("Expires=").append(new java.util.Date(System.currentTimeMillis() + maxAge * 1000L)).append(";");
+        cookieHeader.append("Path=/;");
+        cookieHeader.append("HttpOnly;");
+        cookieHeader.append("Secure;");
+        cookieHeader.append("SameSite=None;");
+
+        response.addHeader("Set-Cookie", cookieHeader.toString());
+    }
+
+    public void deleteCookie(HttpServletResponse response, String name){
+        Cookie cookie = new Cookie(name,null);
+        cookie.setHttpOnly(true);
+        cookie.setPath("/");
+        cookie.setMaxAge(0);
+
+        response.addCookie(cookie);
+    }
+}

--- a/mooney/src/main/java/tamtam/mooney/global/security/CustomLogoutHandler.java
+++ b/mooney/src/main/java/tamtam/mooney/global/security/CustomLogoutHandler.java
@@ -1,0 +1,47 @@
+package tamtam.mooney.global.security;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.web.authentication.logout.LogoutHandler;
+import org.springframework.security.web.authentication.logout.SecurityContextLogoutHandler;
+import org.springframework.stereotype.Component;
+import tamtam.mooney.domain.user.repository.UserRepository;
+import tamtam.mooney.global.exception.ErrorCode;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class CustomLogoutHandler implements LogoutHandler {
+    private final JwtProvider jwtProvider;
+    private final UserRepository userRepository;
+    private final CookieUtil cookieUtil;
+
+    @Override
+    public void logout(HttpServletRequest request, HttpServletResponse response, Authentication authentication) {
+        if (authentication != null && authentication.getName() != null) {
+            String authHeader = request.getHeader("Authorization");
+
+            if (authHeader != null && authHeader.startsWith("Bearer ")) {
+                String accessToken = authHeader.substring(7);
+                jwtProvider.validateAccessToken(accessToken);
+
+                // User 엔티티에서 refreshToken 제거
+                userRepository.findByEmail(authentication.getName()).ifPresent(user -> {
+                    user.setRefreshToken(null);
+                    userRepository.save(user);
+                });
+            }
+            // 쿠키 삭제
+            cookieUtil.deleteCookie(response, "refreshToken");
+
+            // 기본 로그아웃 핸들러 수행
+            SecurityContextLogoutHandler logoutHandler = new SecurityContextLogoutHandler();
+            logoutHandler.logout(request, response, authentication);
+        } else {
+            ErrorResponseUtil.writeErrorResponse(response, ErrorCode.NOT_AUTHENTICATED, request.getRequestURI());
+        }
+    }
+}

--- a/mooney/src/main/java/tamtam/mooney/global/security/CustomUserDetailsService.java
+++ b/mooney/src/main/java/tamtam/mooney/global/security/CustomUserDetailsService.java
@@ -1,0 +1,29 @@
+package tamtam.mooney.global.security;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+import tamtam.mooney.domain.user.entity.User;
+import tamtam.mooney.domain.user.repository.UserRepository;
+import tamtam.mooney.global.exception.CustomException;
+import tamtam.mooney.global.exception.ErrorCode;
+
+@Service
+@RequiredArgsConstructor
+public class CustomUserDetailsService implements UserDetailsService {
+    private final UserRepository userRepository;
+
+    @Override
+    public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
+        User user = userRepository.findByEmail(email)
+                .orElseThrow(() -> new CustomException(ErrorCode.RESOURCE_NOT_FOUND));
+
+        return org.springframework.security.core.userdetails.User.builder()
+                .username(user.getEmail())
+                .password(user.getEncryptedPassword())
+                .roles("USER") // 필요시 Role 추가 가능
+                .build();
+    }
+}

--- a/mooney/src/main/java/tamtam/mooney/global/security/ErrorResponseUtil.java
+++ b/mooney/src/main/java/tamtam/mooney/global/security/ErrorResponseUtil.java
@@ -1,0 +1,39 @@
+package tamtam.mooney.global.security;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.http.HttpServletResponse;
+import tamtam.mooney.global.exception.ErrorCode;
+import tamtam.mooney.global.exception.ErrorResponse;
+
+import java.io.IOException;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+
+public class ErrorResponseUtil {
+
+    private static final ObjectMapper objectMapper = new ObjectMapper();
+
+    public static void writeErrorResponse(HttpServletResponse response, ErrorCode errorCode, String requestUri) {
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+        response.setContentType("application/json");
+        response.setCharacterEncoding("UTF-8");
+
+        // ErrorDto 생성
+        ErrorResponse errorDto = new ErrorResponse(
+                errorCode.getStatus(),
+                errorCode.name(),
+                errorCode.getMessage(),
+                requestUri,
+                LocalDateTime.now().format(DateTimeFormatter.ISO_DATE_TIME),
+                null
+        );
+
+        try {
+            String jsonResponse = objectMapper.writeValueAsString(errorDto);
+            response.getWriter().write(jsonResponse);
+            response.getWriter().flush();
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+}

--- a/mooney/src/main/java/tamtam/mooney/global/security/JwtAuthenticationFilter.java
+++ b/mooney/src/main/java/tamtam/mooney/global/security/JwtAuthenticationFilter.java
@@ -1,0 +1,58 @@
+package tamtam.mooney.global.security;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.filter.OncePerRequestFilter;
+import tamtam.mooney.global.exception.CustomException;
+import tamtam.mooney.global.exception.ErrorCode;
+
+import java.io.IOException;
+
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+    private final JwtProvider jwtProvider;
+    private final CookieUtil cookieUtil;
+    private static final String AUTHORIZATION_HEADER = "Authorization";
+    private static final String BEARER_PREFIX = "Bearer ";
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+        String authorizationHeader = request.getHeader(AUTHORIZATION_HEADER);
+
+        if (authorizationHeader != null && authorizationHeader.startsWith(BEARER_PREFIX)) {
+            String accessToken = authorizationHeader.substring(BEARER_PREFIX.length());
+            try {
+                jwtProvider.validateAccessToken(accessToken); // 엑세스 토큰 유효성을 검증
+                Authentication authentication = jwtProvider.getAuthentication(accessToken);
+                SecurityContextHolder.getContext().setAuthentication(authentication); // 인증된 사용자 정보를 SecurityContext에 저장
+            } catch (CustomException e) {
+                SecurityContextHolder.clearContext();
+                if (e.getErrorCode().equals(ErrorCode.EXPIRED_ACCESS_TOKEN)) {
+                    // 리프레시 토큰 검증을 위해 쿠키에서 리프레시 토큰 가져오기
+                    String refreshToken = cookieUtil.getCookieValue(request, "refreshToken");
+                    if (refreshToken != null) {
+                        try {
+                            // 리프레시 토큰의 유효성을 검증
+                            jwtProvider.validateRefreshToken(refreshToken);
+                            ErrorResponseUtil.writeErrorResponse(response, e.getErrorCode(), request.getRequestURI());
+                            return;
+                        } catch (CustomException ex) {
+                            ErrorResponseUtil.writeErrorResponse(response, ex.getErrorCode(), request.getRequestURI());
+                            return;
+                        }
+                    } else {
+                        ErrorResponseUtil.writeErrorResponse(response, ErrorCode.NO_COOKIE, request.getRequestURI());
+                        return;
+                    }
+                }
+            }
+        }
+        filterChain.doFilter(request,response);  // 다음 필터로 요청을 넘김
+    }
+}
+

--- a/mooney/src/main/java/tamtam/mooney/global/security/JwtProvider.java
+++ b/mooney/src/main/java/tamtam/mooney/global/security/JwtProvider.java
@@ -1,50 +1,107 @@
 package tamtam.mooney.global.security;
 
-import io.jsonwebtoken.Jwts;
-import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.*;
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.Keys;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.stereotype.Component;
+import tamtam.mooney.domain.user.repository.UserRepository;
 import tamtam.mooney.global.exception.CustomException;
 import tamtam.mooney.global.exception.ErrorCode;
 
+import java.security.Key;
 import java.time.Duration;
 import java.util.Date;
 
 @Component
 public class JwtProvider {
-    @Value("${jwt.secret.access}")
-    private String SECRET_KEY;
+    private final Key accessKey;
+    private final Key refreshKey;
+    private final UserRepository userRepository;
+    private final CustomUserDetailsService customUserDetailsService;
+    private static final Duration ACCESS_TOKEN_EXPIRE_TIME = Duration.ofHours(6);
+    private static final Duration REFRESH_TOKEN_EXPIRE_TIME = Duration.ofDays(7);
 
-    private final Duration ACCESS_TOKEN_EXPIRY = Duration.ofDays(1);
-    private final Duration REFRESH_TOKEN_EXPIRY = Duration.ofDays(31);
-
-    public String createAccessToken(Long userId) {
-        return createToken(userId, ACCESS_TOKEN_EXPIRY);
+    public JwtProvider(@Value("${jwt.secret.access}") String accessSecret,
+                       @Value("${jwt.secret.refresh}") String refreshSecret,
+                       UserRepository userRepository, CustomUserDetailsService customUserDetailsService) {
+        this.accessKey = Keys.hmacShaKeyFor(Decoders.BASE64.decode(accessSecret));
+        this.refreshKey = Keys.hmacShaKeyFor(Decoders.BASE64.decode(refreshSecret));
+        this.userRepository = userRepository;
+        this.customUserDetailsService = customUserDetailsService;
     }
 
-    public String createRefreshToken(Long userId) {
-        return createToken(userId, REFRESH_TOKEN_EXPIRY);
+    public String generateAccessToken(String username) {
+        return generateToken(username, accessKey, ACCESS_TOKEN_EXPIRE_TIME);
     }
 
-    private String createToken(Long userId, Duration expiryDuration) {
+    // Redis를 사용하지 않음
+    public String generateRefreshToken(String username) {
+        String refreshToken = generateToken(username, refreshKey, REFRESH_TOKEN_EXPIRE_TIME);
+        userRepository.findByEmail(username).ifPresent(user -> {
+            user.setRefreshToken(refreshToken);
+            userRepository.save(user);
+        });
+        return refreshToken;
+    }
+
+    private String generateToken(String username, Key key, Duration expiredTime) {
+        Claims claims = Jwts.claims().setSubject(username);
+        String role = userRepository.findByEmail(username)
+                .map(user -> user.getRole().name())
+                .orElse("ROLE_USER");
+        claims.put("role", role);
+
         Date now = new Date();
+        Date expireDate = new Date(now.getTime() + expiredTime.toMillis());
+
         return Jwts.builder()
-                .setSubject(String.valueOf(userId))
+                .setClaims(claims)
                 .setIssuedAt(now)
-                .setExpiration(new Date(now.getTime() + expiryDuration.toMillis()))
-                .signWith(SignatureAlgorithm.HS256, SECRET_KEY)
+                .setExpiration(expireDate)
+                .signWith(key, SignatureAlgorithm.HS256)
                 .compact();
     }
 
-    public Long validateToken(String token) {
+    public void validateAccessToken(String accessToken) {
         try {
-            return Long.valueOf(Jwts.parser()
-                    .setSigningKey(SECRET_KEY)
-                    .parseClaimsJws(token)
-                    .getBody()
-                    .getSubject());
-        } catch (Exception e) {
+            Jwts.parserBuilder().setSigningKey(accessKey).build().parseClaimsJws(accessToken);
+        } catch (JwtException e) {
             throw new CustomException(ErrorCode.INVALID_TOKEN);
         }
+    }
+
+    public void validateRefreshToken(String refreshToken) {
+        try {
+            Jwts.parserBuilder().setSigningKey(refreshKey).build().parseClaimsJws(refreshToken);
+        } catch (JwtException e) {
+            throw new CustomException(ErrorCode.INVALID_TOKEN);
+        }
+    }
+
+    public Authentication getAuthentication(String accessToken) {
+        Claims claims = parseClaims(accessToken, accessKey);
+        UserDetails userDetails = customUserDetailsService.loadUserByUsername(claims.getSubject());
+        return new UsernamePasswordAuthenticationToken(userDetails, "", userDetails.getAuthorities());
+    }
+
+    private Claims parseClaims(String token, Key key) {
+        try {
+            return Jwts.parserBuilder()
+                    .setSigningKey(key)
+                    .build()
+                    .parseClaimsJws(token)
+                    .getBody();
+        } catch (ExpiredJwtException e) {
+            return e.getClaims();
+        }
+    }
+
+    public Claims getRefreshTokenClaims(String refreshToken) {
+        return parseClaims(refreshToken, refreshKey);
     }
 }

--- a/mooney/src/main/java/tamtam/mooney/global/security/RedisService.java
+++ b/mooney/src/main/java/tamtam/mooney/global/security/RedisService.java
@@ -1,0 +1,35 @@
+package tamtam.mooney.global.security;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Duration;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class RedisService {
+    private final RedisTemplate<String,Object> redisTemplate;
+
+    // Redis에 값을 설정하고, 지정된 시간 후에 만료되도록 설정
+    public void setValuesWithTimeout(String key, String value, Duration timeout){
+        redisTemplate.opsForValue().set(key,value,timeout);
+    }
+
+    // 키가 존재하지 않을 경우만 값을 설정
+    public boolean setValuesWithTimeoutIfAbsent(String key, String value, Duration timeout){
+        return redisTemplate.opsForValue().setIfAbsent(key, value, timeout);
+    }
+
+    @Transactional(readOnly = true)
+    public Object getValues(String key){
+        return redisTemplate.opsForValue().get(key);
+    }
+
+    // email로 리프레시 토큰을 삭제
+    public void deleteValues(String key) {
+        redisTemplate.delete(key);
+    }
+}


### PR DESCRIPTION
- accessToken, refreshToken 둘 다 사용합니다. (refreshToken은 cookie)
- 빠른 개발 위해 refreshToken은 redis 대신 db에 저장합니다.
- 토큰들 유효 시간은 길게 설정해 두었습니다.