### PR TITLE
[Fix] 예산 진행 API에 budgetUsagePercentage 추가, dto 누락 필드 추가

### DIFF
--- a/mooney/src/main/java/tamtam/mooney/domain/budget/dto/BudgetPlanResponseDto.java
+++ b/mooney/src/main/java/tamtam/mooney/domain/budget/dto/BudgetPlanResponseDto.java
@@ -1,6 +1,5 @@
 package tamtam.mooney.domain.budget.dto;
 
-import jakarta.validation.constraints.NotNull;
 import lombok.Builder;
 
 import java.util.List;

--- a/mooney/src/main/java/tamtam/mooney/domain/budget/dto/BudgetProgressResponseDto.java
+++ b/mooney/src/main/java/tamtam/mooney/domain/budget/dto/BudgetProgressResponseDto.java
@@ -8,6 +8,7 @@ import java.util.List;
 public record BudgetProgressResponseDto(
         Long remainingBudgetAmount,
         Long dailyBudgetAmount,
+        int budgetUsagePercentage,
         Long monthlyBudgetAmount,
         Long pendingExpenseAmount,
         Long totalExpenseAmount,

--- a/mooney/src/main/java/tamtam/mooney/domain/budget/service/BudgetService.java
+++ b/mooney/src/main/java/tamtam/mooney/domain/budget/service/BudgetService.java
@@ -104,9 +104,13 @@ public class BudgetService {
         Long dailyBudgetAmount = remainingDays > 0 ? remainingBudgetAmount / remainingDays : 0;
         List<CategoryBudgetProgressUnitDto> categoryBudgets = categoryBudgetService.getCategoryBudgetProgresses(user, monthlyBudget, startOfMonth, endOfMonth);
 
+        // 사용한 예산 비율 계산
+        int budgetUsagePercentage = (int) ((totalExpenseAmount + pendingExpenseAmount) * 100 / monthlyBudgetAmount);
+
         return BudgetProgressResponseDto.builder()
                 .remainingBudgetAmount(remainingBudgetAmount)
                 .dailyBudgetAmount(dailyBudgetAmount)
+                .budgetUsagePercentage(budgetUsagePercentage)
                 .monthlyBudgetAmount(monthlyBudgetAmount)
                 .pendingExpenseAmount(pendingExpenseAmount)
                 .totalExpenseAmount(totalExpenseAmount)
@@ -123,7 +127,7 @@ public class BudgetService {
 
         // 월 예산 총액
         MonthlyBudget monthlyBudget = monthlyBudgetService.getMonthlyBudget(user, startOfMonth);
-        Long monthlyBudgetAmount = monthlyBudget.getAmount();
+        long monthlyBudgetAmount = monthlyBudget.getAmount();
         // 카테고리별 예산
         List<CategoryBudgetPlanUnitDto> categoryBudgets = categoryBudgetService.getCategoryBudgetPlans(user, monthlyBudget, startOfMonth);
         // 이번 달 고정비 가져오기

--- a/mooney/src/main/java/tamtam/mooney/domain/transaction/dto/ExpenseUnitResponseDto.java
+++ b/mooney/src/main/java/tamtam/mooney/domain/transaction/dto/ExpenseUnitResponseDto.java
@@ -9,7 +9,8 @@ public record ExpenseUnitResponseDto(
         long transactionId,
         long amount,
         LocalDateTime transactionTime,
-        ExpenseCategory expenseCategory,
         String transactionSource,
-        String note
+        String note,
+        String payee,
+        ExpenseCategory expenseCategory
 ) {}

--- a/mooney/src/main/java/tamtam/mooney/domain/transaction/dto/IncomeUnitResponseDto.java
+++ b/mooney/src/main/java/tamtam/mooney/domain/transaction/dto/IncomeUnitResponseDto.java
@@ -10,5 +10,6 @@ public record IncomeUnitResponseDto(
         long amount,
         LocalDateTime transactionTime,
         String transactionSource,
-        String note
+        String note,
+        String payer
 ) {}

--- a/mooney/src/main/java/tamtam/mooney/domain/transaction/service/TransactionService.java
+++ b/mooney/src/main/java/tamtam/mooney/domain/transaction/service/TransactionService.java
@@ -44,9 +44,10 @@ public class TransactionService {
                         expense.getTransactionId(),
                         expense.getAmount(),
                         expense.getTransactionTime(),
-                        expense.getExpenseCategory(),
                         expense.getTransactionSource(),
-                        expense.getNote()
+                        expense.getNote(),
+                        expense.getPayee(),
+                        expense.getExpenseCategory()
                 ));
                 totalExpenseAmount += expense.getAmount();
             } else if (transaction instanceof Income income) {
@@ -55,7 +56,8 @@ public class TransactionService {
                         income.getAmount(),
                         income.getTransactionTime(),
                         income.getTransactionSource(),
-                        income.getNote()
+                        income.getNote(),
+                        income.getPayer()
                 ));
                 totalIncomeAmount += income.getAmount();
             }
@@ -126,9 +128,10 @@ public class TransactionService {
                         expense.getTransactionId(),
                         expense.getAmount(),
                         expense.getTransactionTime(),
-                        expense.getExpenseCategory(),
                         expense.getTransactionSource(),
-                        expense.getNote()
+                        expense.getNote(),
+                        expense.getPayee(),
+                        expense.getExpenseCategory()
                 ))
                 .toList();
     }


### PR DESCRIPTION
# 구현 기능
  - 예산 진행 API에 budgetUsagePercentage 추가
  - ExpenseUnitResponseDto에 payee추가, IncomeUnitResponseDto에 payer 추가

# 구현 상태
  - 완료

# 이슈
  - #7  #14 